### PR TITLE
query status filter

### DIFF
--- a/bash/vote.sh
+++ b/bash/vote.sh
@@ -15,14 +15,13 @@ fi
 chain=${CHAIN_ID:-kaiyo-1}
 fees=${VOTE_FEES:-250ukuji}
 voter=${VOTE_ADDR:-$(${cosmos_exec} keys show -a ${wallet})}
+status_filter=${PROPOSAL_STATUS:-VotingPeriod}
 
 crad="${cosmos_exec} --node ${rpc_node}"
 
-search_status=PROPOSAL_STATUS_VOTING_PERIOD
-
 props_to_vote_on=()
 
-props=$($crad query gov proposals | grep -B 1 $search_status | grep proposal_id | grep -o [[:digit:]]*)
+props=$($crad query gov proposals --status "$status_filter" | grep proposal_id | grep -o [[:digit:]]*)
 [ $? -ne 0 ] && echo "No props need to be voted on!"
 echo "Finding active proposals..."
 echo "*____________________________*"

--- a/bash/vote.sh
+++ b/bash/vote.sh
@@ -4,6 +4,7 @@
 # License: MIT License
 # Description:  Calling './vote.sh' will query the configured RPC server for open votes and interactively walk you through the voting process.
 
+set -e
 cosmos_exec=${CHAIN_DAEMON:-kujirad}
 rpc_node=${RPC:-'https://rpc.kaiyo.kujira.setten.io:443'}
 wallet=${VOTE_WALLET}
@@ -47,8 +48,8 @@ do
   prop_desc=$(echo $prop_info | awk '{ sub(/.*description: /,"");sub(/msg: .*/,"");print}')
   echo "Description: ${prop_desc}"
 
-  prop_myvote=$($crad query gov vote $prop_num $voter 2>/dev/null )
-  [ $? -ne 0 ] && { prop_myvote="Not available!"; props_to_vote_on+=($prop_num); } || \
+  prop_myvote=$($crad query gov vote $prop_num $voter 2>/dev/null) || true
+  [ -z "$prop_myvote" ] && { prop_myvote="Not available!"; props_to_vote_on+=($prop_num); } || \
   prop_myvote=$(echo $prop_myvote | awk '{ sub(/option: /,"");sub(/options: .*/,"");print}')
   echo "My Vote: ${prop_myvote}"
   echo "*____________________________*"


### PR DESCRIPTION
Uses the `--status` query filter to return only proposals in the voting period by default. This is more efficient and prevents issues when the proposal count exceeds the page limit. PR also includes an update to make the script exit on errors so it won't try to continue if the wallet lookup or most other queries fail.